### PR TITLE
Update redis examples with specifc DB

### DIFF
--- a/examples/redis/redis-cr-2.yaml
+++ b/examples/redis/redis-cr-2.yaml
@@ -13,4 +13,4 @@ spec:
     value: system
   dbHost: system-redis
   dbPort: 6379
-  dbCheckKeys: queue:backend_sync,queue:billing,queue:critical,queue:default,queue:deletion,queue:events,queue:low,queue:priority,queue:web_hooks,queue_zync
+  dbCheckKeys: "db1=queue:backend_sync,db1=queue:billing,db1=queue:critical,db1=queue:default,db1=queue:deletion,db1=queue:events,db1=queue:low,db1=queue:priority,db1=queue:web_hooks,db1=queue:zync"

--- a/examples/redis/redis-cr.yaml
+++ b/examples/redis/redis-cr.yaml
@@ -13,4 +13,4 @@ spec:
     value: backend
   dbHost: backend-redis
   dbPort: 6379
-  dbCheckKeys: resque:queue:stats,resque:queue:priority,resque:queue:main,resque:failed
+  dbCheckKeys: "db1=resque:queue:stats,db1=resque:queue:priority,db1=resque:queue:main,db1=resque:failed"


### PR DESCRIPTION
Updated examples of redis custom resources, specifying in which redis database the key is stored.

By default on a 3scale deployment, redis queues on both system and backend applications are stored on `db1` instead of `db0` (default), so it needs to be specified on the CR variable `dbCheckKeys` of the Custom Resource `PrometheusExporter`