### PR TITLE
Add documentation about how to run the operator locally for dev purpose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: operator-image-update operator-manual-deploy operator-manual-delete operator-olm-deploy operator-olm-delete manifests-generate manifests-verify manifests-push prometheus-rules-deploy prometheus-rules-delete help
+.PHONY: operator-image-update operator-local-deploy operator-manual-deploy operator-manual-delete operator-olm-deploy operator-olm-delete manifests-generate manifests-verify manifests-push prometheus-rules-deploy prometheus-rules-delete help
 
 .DEFAULT_GOAL := help
 
@@ -36,6 +36,9 @@ operator-image-update: operator-image-build operator-image-push ## OPERATOR IMAG
 namespace-create: # NAMESPACE MANAGEMENT - Create namespace for the operator
 	$(KUBE_CLIENT) create namespace $(NAMESPACE) || true
 	$(KUBE_CLIENT) label namespace $(NAMESPACE) monitoring-key=middleware || true
+
+operator-local-deploy: namespace-create ## OPERATOR LOCAL DEPLOY - Deploy Operator locally for dev purpose
+	operator-sdk run --local --watch-namespace $(NAMESPACE)
 
 operator-manual-deploy: namespace-create ## OPERATOR MANUAL DEPLOY - Deploy Operator objects (namespace, CRD, service account, role, role binding and operator deployment)
 	$(KUBE_CLIENT) apply -f deploy/crds/monitoring.3scale.net_prometheusexporters_crd.yaml --validate=false || true

--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ $ make prometheus-rules-deploy
 $ make prometheus-rules-delete
 ```
 
+## Development
+
+To run the operator locally you need to install some ansible dependencies first:
+
+* ansible-runner: `sudo dnf install python-ansible-runner`
+* ansible-runner-http: `pip install python-ansible-runner`
+* openshift ansible module: `pip install openshift`
+
+You can then run the operator with the following command:
+
+```bash
+operator-sdk run --local --watch-namespace <namespace>
+```
+
 ## Contributing
 
 You can contribute by:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,6 +10,13 @@ $ make operator-image-update
 
 ## Operator deploy
 
+### Local deploy
+* Deploy operator locally for developmnt purpose without generating a new image:
+```bash
+$ make operator-local-deploy
+```
+* Create any `PrometheusExporter` resource type (you can find examples on [examples](../examples/) directory).
+
 ### Manual deploy
 * Deploy operator (namespace, CRD, service account, role, role binding and operator deployment):
 ```bash


### PR DESCRIPTION
Add documentation about how to deploy the operator locally without deploying anything on a cluster, when you are developing and don't want/need to generate a new operator image.