### PR TITLE
Feat/Add AWS CloudWatch support to AWSClientVPN service

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -157,6 +157,8 @@ $ make elasticsearch-delete
 ## AWS CloudWatch
 
 * Official doc: https://github.com/prometheus/cloudwatch_exporter
+> **NOTE**
+><br /> The metrics from some services like `AWSClientVPN` are reported to AWS CloudWatch every **5 minutes** (instead of default **1 minute**), because they are not critical services like databases (RDS/EC) where details are more important. So on thoses cases, scrapping AWS Cloudwatch metrics every 1 minute makes no sense, so it is better to specify the var `period_seconds: 300` (instead of default `period_seconds: 60`) in the metric definition in the configmap. In addition, for those cases reporting metrics every 5 minutes, empty spaces (null values) could appear empty in the prometheus time series database, so in order to configure alerts, you can use queries like `max_over_time(aws_clientvpn_crl_days_to_expiry_average[10m]) < 2`, which takes max value within last 10 minutes, so we guarantee there is always a value that can fire an alert that won't disappear from time to time although alert might not be really recovered.
 
 ### CR needed extra objects
 

--- a/examples/cloudwatch/cloudwatch-configmap.yaml
+++ b/examples/cloudwatch/cloudwatch-configmap.yaml
@@ -170,3 +170,28 @@ data:
        aws_metric_name: HTTPCode_Backend_5XX
        aws_dimensions: [LoadBalancerName]
        aws_statistics: [Sum]
+     - aws_namespace: AWS/ClientVPN
+       aws_metric_name: CrlDaysToExpiry
+       aws_dimensions: [Endpoint]
+       aws_statistics: [Average]
+       period_seconds: 300
+     - aws_namespace: AWS/ClientVPN
+       aws_metric_name: ActiveConnectionsCount
+       aws_dimensions: [Endpoint]
+       aws_statistics: [Average]
+       period_seconds: 300
+     - aws_namespace: AWS/ClientVPN
+       aws_metric_name: AuthenticationFailures
+       aws_dimensions: [Endpoint]
+       aws_statistics: [Average]
+       period_seconds: 300
+     - aws_namespace: AWS/ClientVPN
+       aws_metric_name: IngressBytes
+       aws_dimensions: [Endpoint]
+       aws_statistics: [Average]
+       period_seconds: 300
+     - aws_namespace: AWS/ClientVPN
+       aws_metric_name: EgressBytes
+       aws_dimensions: [Endpoint]
+       aws_statistics: [Average]
+       period_seconds: 300

--- a/prometheus-rules/cloudwatch-prometheusrule.yaml
+++ b/prometheus-rules/cloudwatch-prometheusrule.yaml
@@ -55,3 +55,10 @@ spec:
           severity: critical
         annotations:
           message: "AWS RDS instance {{ $labels.dbinstance_identifier }} from {{ $labels.prometheus_exporter }} has Low Free Storage Space usage (bytes)"
+      - alert: AWSClientVPNCrlDaysToExpiry
+        expr: max_over_time(aws_clientvpn_crl_days_to_expiry_average[10m]) < 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          message: "AWS ClientVPN CRL {{ $labels.endpoint }} will expire soon, maybe it is not being regenerated"

--- a/roles/prometheusexporter/templates/grafanadashboard-cloudwatch.yml.j2
+++ b/roles/prometheusexporter/templates/grafanadashboard-cloudwatch.yml.j2
@@ -3408,7 +3408,7 @@ spec:
                 "h": 6,
                 "w": 6,
                 "x": 0,
-                "y": 120
+                "y": 24
               },
               "id": 41,
               "links": [],
@@ -3462,7 +3462,7 @@ spec:
                 "h": 6,
                 "w": 6,
                 "x": 6,
-                "y": 120
+                "y": 24
               },
               "id": 42,
               "links": [],
@@ -3516,7 +3516,7 @@ spec:
                 "h": 6,
                 "w": 6,
                 "x": 12,
-                "y": 120
+                "y": 24
               },
               "id": 43,
               "links": [],
@@ -3570,7 +3570,7 @@ spec:
                 "h": 6,
                 "w": 6,
                 "x": 18,
-                "y": 120
+                "y": 24
               },
               "id": 44,
               "links": [],
@@ -3628,7 +3628,7 @@ spec:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 126
+                "y": 30
               },
               "id": 46,
               "legend": {
@@ -3715,7 +3715,7 @@ spec:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 126
+                "y": 30
               },
               "id": 40,
               "legend": {
@@ -3802,7 +3802,7 @@ spec:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 134
+                "y": 38
               },
               "id": 39,
               "legend": {
@@ -3889,7 +3889,7 @@ spec:
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 134
+                "y": 38
               },
               "id": 45,
               "legend": {
@@ -3967,6 +3967,460 @@ spec:
             }
           ],
           "title": "AWS ElasticSearch",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 24
+          },
+          "id": 74,
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$datasource",
+              "fill": 1,
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 25
+              },
+              "id": 75,
+              "interval": "",
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "options": {},
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "aws_clientvpn_crl_days_to_expiry_average{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ '{{' }} exported_endpoint {{ '}}' }}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "CRL days to expiry Average",
+              "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 0,
+                  "format": "none",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$datasource",
+              "fill": 1,
+              "gridPos": {
+                "h": 8,
+                "w": 6,
+                "x": 12,
+                "y": 25
+              },
+              "id": 76,
+              "interval": "",
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "options": {},
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "aws_clientvpn_active_connections_count_average{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ '{{' }} exported_endpoint {{ '}}' }}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Active Connection Count Average",
+              "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 0,
+                  "format": "none",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$datasource",
+              "fill": 1,
+              "gridPos": {
+                "h": 8,
+                "w": 6,
+                "x": 18,
+                "y": 25
+              },
+              "id": 77,
+              "interval": "",
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "options": {},
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "aws_clientvpn_authentication_failures_average{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ '{{' }} exported_endpoint {{ '}}' }}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Authentication Failures Average",
+              "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 0,
+                  "format": "none",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$datasource",
+              "fill": 1,
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 33
+              },
+              "id": 78,
+              "interval": "",
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "options": {},
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "aws_clientvpn_ingress_bytes_average{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ '{{' }} exported_endpoint {{ '}}' }}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Ingress Bytes Average",
+              "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 0,
+                  "format": "bytes",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$datasource",
+              "fill": 1,
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 33
+              },
+              "id": 79,
+              "interval": "",
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "connected",
+              "options": {},
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "aws_clientvpn_egress_bytes_average{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ '{{' }} exported_endpoint {{ '}}' }}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Egress Bytes Average",
+              "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 0,
+                  "format": "bytes",
+                  "label": "",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            }
+          ],
+          "title": "AWS ClientVPN",
           "type": "row"
         }
       ],


### PR DESCRIPTION
On 3scale SaaS we use AWS ClientVPN to manage the VPN access to our different VPCs on different AWS Accounts, so we need to have monitoring around it.

For that reason this PR add supports to AWSClientVPN service, by providing:
- Some AWSClientVPN grafana dashboard panels with more important metrics
![image](https://user-images.githubusercontent.com/41513123/97699567-a3373980-1aaa-11eb-8ea0-da7db470bd59.png)
- Metrics configuration file with required AWSClientVPN metrics, and some hints like using `period_seconds: 300` because the metrics from that Service are reported to CW every 5min instead of default 1min.
- An example of AWSClientVPN PrometheusRule to monitor CRL expiration in days, as we manage the CRL with an external tool that update the CRL regularly, but it can fail and we need to know if it fails. As this AWSClientVPN metrics are not reportted much often, sometimes appear gaps in the timeseries database, so it is recommended using promql queries with functions like `max_over_time(aws_clientvpn_crl_days_to_expiry_average[10m]) < 2`, which takes max value within last 10 minutes, so we guarantee there is always a value that can fire an alert that won't disappear from time to time although alert might not be really recovered. 
- Documentation about those services reporting metrics less often than others, which require an special finetunning

