### PR TITLE
Fix ES dashboard version query to limit the results to one version

### DIFF
--- a/roles/prometheusexporter/templates/grafanadashboard-es.yml.j2
+++ b/roles/prometheusexporter/templates/grafanadashboard-es.yml.j2
@@ -303,7 +303,7 @@ spec:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "elasticsearch_clusterinfo_version_info{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
+              "expr": "sum(elasticsearch_clusterinfo_version_info{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}) by (version)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,


### PR DESCRIPTION
By some reason, I discovered on a single node AWS Elasticsearch cluster with the minimum node instance type (t2.small) with limited resources, that node disappear from AWS console and so, their CW metrics were not reported, although cluster was still active and correctly reported by es-exporter. I needed to change instance-type (or add a node or increase EBS), so AWS triggered the change and fixed the problem, the new node appears on AWS.

However, since this ghost node replacement in AWS, ES dashboard is showing an error on version panel (because it expects a single time series databases with metric elasticsearch_clusterinfo_version_info`, but there are 2 different time series database showing same ES version, but with 2 different build_date, while in reality there should be a single node with its own build_date):

![image](https://user-images.githubusercontent.com/41513123/97705884-1180f980-1ab5-11eb-8afc-5a62db1e3709.png)


For that reason, in order to limit the results to a single one, given the fact this is only affecting to a readonly metric, and I don't know if the problem comes from the exporter itself, or from AWS due to the issue explained above, I have just updated the promql query to do a `sum by version`