### PR TITLE
Feat/Improve AWS CloudWatch Elasticsearch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,10 @@ manifests-push: ## OPERATOR OLM CSV - Push CSV manifests to remote application r
 	operator-courier --verbose push deploy/olm-catalog/$(PROJECT)/ $(MANIFESTS_PROJECT) $(PROJECT) $(MANIFESTS_VERSION) "$(AUTH_TOKEN)"
 
 ## Prometheus rules ##
-prometheus-rules-deploy: namespace-create ## PROMETHEUS RULES - Create Prometheus Rules (Memcached, Redis, MySQL, PostgreSQL, Sphinx, ElasticSearch, Cloudwatch)
+prometheus-rules-deploy: namespace-create ## PROMETHEUS RULES - Create Prometheus Rules (Memcached, Redis, MySQL, PostgreSQL, Sphinx, Elasticsearch, Cloudwatch)
 	$(KUBE_CLIENT) apply -f prometheus-rules/ -n $(NAMESPACE)
 
-prometheus-rules-delete: ## PROMETHEUS RULES - Delete Prometheus Rules (Memcached, Redis, MySQL, PostgreSQL, Sphinx, ElasticSearch, Cloudwatch)
+prometheus-rules-delete: ## PROMETHEUS RULES - Delete Prometheus Rules (Memcached, Redis, MySQL, PostgreSQL, Sphinx, Elasticsearch, Cloudwatch)
 	$(KUBE_CLIENT) delete -f prometheus-rules/ -n $(NAMESPACE) || true
 
 help: ## Print this help

--- a/docs/prometheus-exporter-crd-reference.md
+++ b/docs/prometheus-exporter-crd-reference.md
@@ -128,12 +128,12 @@ Specific CR fields per exporter type:
 * Image, port, resources, liveness, readiness default values can be found at [ansible-sphinx-vars](../roles/prometheusexporter/vars/sphinx.yml)
 * Real `sphinx` example can be found on [examples](../examples/README.md#sphinx) directory.
 
-### CR Spec Custom Type Es (ElasticSearch)
+### CR Spec Custom Type Es (Elasticsearch)
 
 | **Field** | **Type** | **Required** | **Default value** | **Description** |
 |:---:|:---:|:---:|:---:|:---:|
-| `dbHost` | `string`| Yes | `http://elasticsearch` | ElasticSearch Host (could be k8s service or any internal/external DNS endpoint) |
-| `dbPort` | `int`| Yes | `9200` | ElasticSearch Port |
+| `dbHost` | `string`| Yes | `http://elasticsearch` | Elasticsearch Host (could be k8s service or any internal/external DNS endpoint) |
+| `dbPort` | `int`| Yes | `9200` | Elasticsearch Port |
 
 * Image, port, resources, liveness, readiness default values can be found at [ansible-es-vars](../roles/prometheusexporter/vars/es.yml)
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -57,7 +57,7 @@ sphinx-create: ## SPHINX EXAMPLE - Create: CR (you need to provide a sphinx inst
 sphinx-delete: ## SPHINX EXAMPLE - Delete: CR
 	$(KUBE_CLIENT) delete -f sphinx/ -n $(NAMESPACE) || true
 
-## ElasticSearch ##
+## Elasticsearch ##
 
 elasticsearch-create:  ## ELASTICSEARCH EXAMPLE - Create: CR (you need to provide a ES cluster in advance)
 	$(KUBE_CLIENT) apply -f elasticsearch/ --validate=false -n $(NAMESPACE)

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ Once the deployed prometheus-exporter operator is up and running and watching fo
 1. [MySQL](#mysql)
 1. [PostgreSQL](#postgresql)
 1. [Sphinx](#sphinx)
-1. [ElasticSearch](#elasticsearch)
+1. [Elasticsearch](#elasticsearch)
 1. [AWS CloudWatch](#aws-cloudwatch)
 
 ## Memcached
@@ -138,13 +138,13 @@ $ make sphinx-create
 $ make sphinx-delete
 ```
 
-## ElasticSearch
+## Elasticsearch
 
 * Official doc: https://github.com/justwatchcom/elasticsearch_exporter
 
 ### Deploy example
 
-* **Make sure you have an ElasticSearch cluster available and that dbHost/dbPort are correctly set on CR example file**
+* **Make sure you have an Elasticsearch cluster available and that dbHost/dbPort are correctly set on CR example file**
 * Create `elasticsearch-exporter` example ([example-CR](elasticsearch/es-cr.yaml)):
 ```bash
 $ make elasticsearch-create

--- a/examples/cloudwatch/cloudwatch-configmap.yaml
+++ b/examples/cloudwatch/cloudwatch-configmap.yaml
@@ -80,15 +80,27 @@ data:
        aws_statistics: [Maximum]
      - aws_namespace: AWS/ES
        aws_metric_name: FreeStorageSpace
-       aws_dimensions: [DomainName, ClientId]
+       aws_dimensions: [DomainName, ClientId, NodeId]
        aws_statistics: [Minimum]
      - aws_namespace: AWS/ES
        aws_metric_name: CPUUtilization
-       aws_dimensions: [DomainName, ClientId]
+       aws_dimensions: [DomainName, ClientId, NodeId]
        aws_statistics: [Maximum]
      - aws_namespace: AWS/ES
        aws_metric_name: JVMMemoryPressure
-       aws_dimensions: [DomainName, ClientId]
+       aws_dimensions: [DomainName, ClientId, NodeId]
+       aws_statistics: [Maximum]
+     - aws_namespace: AWS/ES
+       aws_metric_name: MasterFreeStorageSpace
+       aws_dimensions: [DomainName, ClientId, NodeId]
+       aws_statistics: [Minimum]
+     - aws_namespace: AWS/ES
+       aws_metric_name: MasterCPUUtilization
+       aws_dimensions: [DomainName, ClientId, NodeId]
+       aws_statistics: [Maximum]
+     - aws_namespace: AWS/ES
+       aws_metric_name: MasterJVMMemoryPressure
+       aws_dimensions: [DomainName, ClientId, NodeId]
        aws_statistics: [Maximum]
      - aws_namespace: AWS/ApplicationELB
        aws_metric_name: HealthyHostCount

--- a/prometheus-rules/cloudwatch-prometheusrule.yaml
+++ b/prometheus-rules/cloudwatch-prometheusrule.yaml
@@ -55,6 +55,20 @@ spec:
           severity: critical
         annotations:
           message: "AWS RDS instance {{ $labels.dbinstance_identifier }} from {{ $labels.prometheus_exporter }} has Low Free Storage Space usage (bytes)"
+      - alert: AWSElasticsearchClusterStatusYellow
+        expr: aws_es_cluster_status_yellow_maximum == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          message: "AWS Elasticsearch {{ $labels.domain_name }} from {{ $labels.prometheus_exporter }} cluster status is Yellow"
+      - alert: AWSElasticsearchClusterStatusRed
+        expr: aws_es_cluster_status_red_maximum == 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          message: "AWS Elasticsearch {{ $labels.domain_name }} from {{ $labels.prometheus_exporter }} cluster status is Red"
       - alert: AWSClientVPNCrlDaysToExpiry
         expr: max_over_time(aws_clientvpn_crl_days_to_expiry_average[10m]) < 2
         for: 5m

--- a/prometheus-rules/es-prometheusrule.yaml
+++ b/prometheus-rules/es-prometheusrule.yaml
@@ -7,73 +7,73 @@ spec:
     - name: prometheus-exporter-es.rules
       rules:
         # Cluster status alerts
-        - alert: ElasticSearchDown
+        - alert: ElasticsearchDown
           expr: elasticsearch_cluster_health_up == 0
           for: 1m
           labels:
             severity: critical
           annotations:
-            message: "ElasticSearch {{ $labels.prometheus_exporter }} is DOWN"
-        - alert: ElasticSearchClusterStatusYellow
+            message: "Elasticsearch {{ $labels.prometheus_exporter }} is DOWN"
+        - alert: ElasticsearchClusterStatusYellow
           expr: elasticsearch_cluster_health_status {color="yellow"} == 1
           for: 1m
           labels:
             severity: warning
           annotations:
-            message: "ElasticSearch {{ $labels.prometheus_exporter }} Cluster Status is Yellow"
-        - alert: ElasticSearchClusterStatusRed
+            message: "Elasticsearch {{ $labels.prometheus_exporter }} Cluster Status is Yellow"
+        - alert: ElasticsearchClusterStatusRed
           expr: elasticsearch_cluster_health_status {color="red"} == 1
           for: 1m
           labels:
             severity: critical
           annotations:
-            message: "ElasticSearch {{ $labels.prometheus_exporter }} Cluster Status is Red"
+            message: "Elasticsearch {{ $labels.prometheus_exporter }} Cluster Status is Red"
 
         # Memory alerts
-        - alert: ElasticSearchNodeHeapMemoryHigh
+        - alert: ElasticsearchNodeHeapMemoryHigh
           expr: 100* elasticsearch_jvm_memory_used_bytes{area="heap"} / elasticsearch_jvm_memory_max_bytes{area="heap"} > 85
           for: 10m
           labels:
             severity: warning
           annotations:
-            message: "ElasticSearch node {{ $labels.name }} Heap Memory usage is High"
-        - alert: ElasticSearchNodeHeapMemoryHigh
+            message: "Elasticsearch node {{ $labels.name }} Heap Memory usage is High"
+        - alert: ElasticsearchNodeHeapMemoryHigh
           expr: 100* elasticsearch_jvm_memory_used_bytes{area="heap"} / elasticsearch_jvm_memory_max_bytes{area="heap"} > 95
           for: 10m
           labels:
             severity: critical
           annotations:
-            message: "ElasticSearch node {{ $labels.name }} Heap Memory usage is High"
+            message: "Elasticsearch node {{ $labels.name }} Heap Memory usage is High"
 
-        - alert: ElasticSearchNodeFreeSpaceLow
+        - alert: ElasticsearchNodeFreeSpaceLow
           expr: 100 -( 100 * (elasticsearch_filesystem_data_size_bytes - elasticsearch_filesystem_data_free_bytes)/ elasticsearch_filesystem_data_size_bytes) < 15
           for: 10m
           labels:
             severity: warning
           annotations:
-            message: "ElasticSearch node {{ $labels.name }} has Low Free space"
-        - alert: ElasticSearchNodeFreeSpaceLow
+            message: "Elasticsearch node {{ $labels.name }} has Low Free space"
+        - alert: ElasticsearchNodeFreeSpaceLow
           expr: 100 -( 100 * (elasticsearch_filesystem_data_size_bytes - elasticsearch_filesystem_data_free_bytes)/ elasticsearch_filesystem_data_size_bytes) < 5
           for: 10m
           labels:
             severity: critical
           annotations:
-            message: "ElasticSearch node {{ $labels.name }} has Low Free space"
+            message: "Elasticsearch node {{ $labels.name }} has Low Free space"
 
-        - alert: ElasticSearchWillFillIn96h
+        - alert: ElasticsearchWillFillIn96h
           expr: predict_linear(elasticsearch_filesystem_data_free_bytes{}[24h], 96 * 3600) < 0
           for: 1h
           labels:
             severity: warning
           annotations:
-            message: "ElasticSearch node {{ $labels.name }} will fill in 4 days"
-        - alert: ElasticSearchNodeWillFillIn24h
+            message: "Elasticsearch node {{ $labels.name }} will fill in 4 days"
+        - alert: ElasticsearchNodeWillFillIn24h
           expr: predict_linear(elasticsearch_filesystem_data_free_bytes{}[24h], 24 * 3600) < 0
           for: 1h
           labels:
             severity: critical
           annotations:
-            message: "ElasticSearch node {{ $labels.name }} will fill in 24h"
+            message: "Elasticsearch node {{ $labels.name }} will fill in 24h"
 
         # CPU alerts
         - alert: ElasticSeachNodeHighCPU
@@ -82,11 +82,11 @@ spec:
           labels:
             severity: warning
           annotations:
-            message: "ElasticSearch node {{ $labels.name }} has high CPU usage"
+            message: "Elasticsearch node {{ $labels.name }} has high CPU usage"
         - alert: ElasticSeachNodeHighCPU
           expr: elasticsearch_os_cpu_percent > 95
           for: 10m
           labels:
             severity: critical
           annotations:
-            message: "ElasticSearch node {{ $labels.name }} has high CPU usage"
+            message: "Elasticsearch node {{ $labels.name }} has high CPU usage"

--- a/roles/prometheusexporter/templates/grafanadashboard-cloudwatch.yml.j2
+++ b/roles/prometheusexporter/templates/grafanadashboard-cloudwatch.yml.j2
@@ -3991,7 +3991,7 @@ spec:
               }
             }
           ],
-          "title": "AWS ElasticSearch",
+          "title": "AWS Elasticsearch",
           "type": "row"
         },
         {

--- a/roles/prometheusexporter/templates/grafanadashboard-cloudwatch.yml.j2
+++ b/roles/prometheusexporter/templates/grafanadashboard-cloudwatch.yml.j2
@@ -3410,6 +3410,7 @@ spec:
                 "x": 0,
                 "y": 24
               },
+              "hideTimeOverride": true,
               "id": 41,
               "links": [],
               "options": {
@@ -3450,8 +3451,8 @@ spec:
                   "refId": "A"
                 }
               ],
-              "timeFrom": null,
-              "timeShift": null,
+              "timeFrom": "5m",
+              "timeShift": "5m",
               "title": "Cluster Status GREEN Maximum",
               "type": "bargauge"
             },
@@ -3464,6 +3465,7 @@ spec:
                 "x": 6,
                 "y": 24
               },
+              "hideTimeOverride": true,
               "id": 42,
               "links": [],
               "options": {
@@ -3504,8 +3506,8 @@ spec:
                   "refId": "A"
                 }
               ],
-              "timeFrom": null,
-              "timeShift": null,
+              "timeFrom": "5m",
+              "timeShift": "5m",
               "title": "Cluster Status YELLOW Maximum",
               "type": "bargauge"
             },
@@ -3518,6 +3520,7 @@ spec:
                 "x": 12,
                 "y": 24
               },
+              "hideTimeOverride": true,
               "id": 43,
               "links": [],
               "options": {
@@ -3558,8 +3561,8 @@ spec:
                   "refId": "A"
                 }
               ],
-              "timeFrom": null,
-              "timeShift": null,
+              "timeFrom": "5m",
+              "timeShift": "5m",
               "title": "Cluster Status RED Maximum",
               "type": "bargauge"
             },
@@ -3572,6 +3575,7 @@ spec:
                 "x": 18,
                 "y": 24
               },
+              "hideTimeOverride": true,
               "id": 44,
               "links": [],
               "options": {
@@ -3612,8 +3616,8 @@ spec:
                   "refId": "A"
                 }
               ],
-              "timeFrom": null,
-              "timeShift": null,
+              "timeFrom": "5m",
+              "timeShift": "5m",
               "title": "Automated Snapshot Failure Maximum",
               "type": "bargauge"
             },
@@ -3669,7 +3673,7 @@ spec:
               "title": "Cluster Number Nodes Maximum",
               "tooltip": {
                 "shared": true,
-                "sort": 1,
+                "sort": 2,
                 "value_type": "individual"
               },
               "type": "graph",
@@ -3745,8 +3749,15 @@ spec:
                   "expr": "aws_es_free_storage_space_minimum{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
                   "format": "time_series",
                   "intervalFactor": 1,
-                  "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}",
+                  "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}-data-{{ '{{' }} node_id {{ '}}' }}",
                   "refId": "A"
+                },
+                {
+                  "expr": "aws_es_master_free_storage_space_minimum{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}-master-{{ '{{' }} node_id {{ '}}' }}",
+                  "refId": "B"
                 }
               ],
               "thresholds": [],
@@ -3756,7 +3767,7 @@ spec:
               "title": "Free Storage Space Minimum (megabytes)",
               "tooltip": {
                 "shared": true,
-                "sort": 1,
+                "sort": 2,
                 "value_type": "individual"
               },
               "type": "graph",
@@ -3832,8 +3843,15 @@ spec:
                   "expr": "aws_es_cpuutilization_maximum{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
                   "format": "time_series",
                   "intervalFactor": 1,
-                  "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}",
+                  "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}-data-{{ '{{' }} node_id {{ '}}' }}",
                   "refId": "A"
+                },
+                {
+                  "expr": "aws_es_master_cpuutilization_maximum{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}-master-{{ '{{' }} node_id {{ '}}' }}",
+                  "refId": "B"
                 }
               ],
               "thresholds": [],
@@ -3919,8 +3937,15 @@ spec:
                   "expr": "aws_es_jvmmemory_pressure_maximum{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
                   "format": "time_series",
                   "intervalFactor": 1,
-                  "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}",
+                  "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}-data-{{ '{{' }} node_id {{ '}}' }}",
                   "refId": "A"
+                },
+                {
+                  "expr": "aws_es_master_jvmmemory_pressure_maximum{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}-master-{{ '{{' }} node_id {{ '}}' }}",
+                  "refId": "B"
                 }
               ],
               "thresholds": [],

--- a/roles/prometheusexporter/templates/grafanadashboard-es.yml.j2
+++ b/roles/prometheusexporter/templates/grafanadashboard-es.yml.j2
@@ -2882,6 +2882,6 @@ spec:
         ]
       },
       "timezone": "browser",
-      "title": "{{ meta.namespace }} / PrometheusExporter ElasticSearch",
+      "title": "{{ meta.namespace }} / PrometheusExporter Elasticsearch",
       "version": 1
     }


### PR DESCRIPTION
It has been improved AWS CloudWatch Elasticsearch by:
- Adding a few example alerts of cluster status yellow/red
- Adding new master nodes metrics to example configmap
- Improving grafana dashboard promql queries with nodes information (freeStorage, CPU, JVMPressure) by adding information about role in the cluster (data/master) and nodeId (which identifies the underlying ES host)
![image](https://user-images.githubusercontent.com/41513123/97728989-7d258f80-1ad2-11eb-8a08-3261d8968a88.png)

- Replacement all incorrect `ElasticSearch` string by correct  `Elasticsearch` (without camel case)