### PR TITLE
Improve Elasticsearch dashboard

### DIFF
--- a/roles/prometheusexporter/templates/grafanadashboard-es.yml.j2
+++ b/roles/prometheusexporter/templates/grafanadashboard-es.yml.j2
@@ -1325,7 +1325,7 @@ spec:
           "title": "Documents Indexed Rate",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -1412,7 +1412,7 @@ spec:
           "title": "Query Rate",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -1505,7 +1505,7 @@ spec:
           "tooltip": {
             "msResolution": true,
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "cumulative"
           },
           "type": "graph",
@@ -1608,7 +1608,7 @@ spec:
           "tooltip": {
             "msResolution": true,
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "cumulative"
           },
           "type": "graph",
@@ -1698,7 +1698,7 @@ spec:
           "tooltip": {
             "msResolution": true,
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "cumulative"
           },
           "type": "graph",
@@ -1792,11 +1792,11 @@ spec:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "RX/TX Rate",
+          "title": "RX/TX Packets rate",
           "tooltip": {
             "msResolution": true,
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "cumulative"
           },
           "type": "graph",
@@ -1889,7 +1889,7 @@ spec:
           "tooltip": {
             "msResolution": true,
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "cumulative"
           },
           "type": "graph",
@@ -1981,7 +1981,7 @@ spec:
           "tooltip": {
             "msResolution": true,
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "cumulative"
           },
           "type": "graph",
@@ -2094,7 +2094,7 @@ spec:
           "yaxes": [
             {
               "decimals": 1,
-              "format": "short",
+              "format": "percent",
               "label": null,
               "logBase": 1,
               "max": "100",
@@ -2182,7 +2182,7 @@ spec:
           "yaxes": [
             {
               "decimals": 1,
-              "format": "short",
+              "format": "percent",
               "label": null,
               "logBase": 1,
               "max": "100",
@@ -2256,7 +2256,7 @@ spec:
           "title": "CPU usage (master nodes)",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -2270,7 +2270,7 @@ spec:
           "yaxes": [
             {
               "decimals": null,
-              "format": "short",
+              "format": "percent",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -2357,7 +2357,7 @@ spec:
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "percent",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -2618,7 +2618,7 @@ spec:
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "percent",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -2692,7 +2692,7 @@ spec:
           "title": "Memory usage (master nodes)",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -2705,7 +2705,7 @@ spec:
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "percent",
               "label": null,
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
This PR:
- Adds  % unit to panels showing percentage values (cpu, memory, storage occupied)
- Adds the same order "`Decreasing`" to all panels, which helps to check outer layer results when having lots of metrics per panel