### PR TITLE
Fix Probe (blackbox) grafana dashboard

### DIFF
--- a/roles/prometheusexporter/templates/grafanadashboard-probe.yml.j2
+++ b/roles/prometheusexporter/templates/grafanadashboard-probe.yml.j2
@@ -766,23 +766,7 @@ spec:
           "title": "SSL Expiry",
           "type": "singlestat",
           "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            },
-            {
-              "op": "=",
-              "text": "YES",
-              "value": "1"
-            },
-            {
-              "op": "=",
-              "text": "NO",
-              "value": "0"
-            }
-          ],
+          "valueMaps": [],
           "valueName": "current"
         },
         {

--- a/roles/prometheusexporter/templates/grafanadashboard-probe.yml.j2
+++ b/roles/prometheusexporter/templates/grafanadashboard-probe.yml.j2
@@ -1032,7 +1032,7 @@ spec:
                 "$__all"
               ]
             },
-            "datasource": "Prometheus",
+            "datasource": "$datasource",
             "definition": "label_values(probe_success{namespace=\"$namespace\",service=~\".*$prometheus_exporter\"}, target)",
             "hide": 0,
             "includeAll": true,


### PR DESCRIPTION
There were 2 issues with current Probe (blackbox) grafana dashboard:
1. When dashboard is deployed, it was failing to load because by accident, template variable `target` was doing a prometheus query using harcoded `Prometheus` datasource. This can be truth or not, there is another template var checking the possible correct datasource name.
1. The singlestat showing the expiration date of SSL certificate, whose format is `duration(s)`, was showing `YES` instead of the actual date `1month, 2 weeks, 2 days` on some grafana versions like grafana v6.5.1 (from grafana operator 3.5), different to the version used when adding the dashboard:
![image](https://user-images.githubusercontent.com/41513123/100111690-a2f24a00-2e6e-11eb-8d5a-440a1dd5464b.png)

It seems this is caused on some grafana versions, when using specifically on a **singlestat panel**, **value mappings** ( on that case `null` -> `N/A`, `1` -> `NO`, `0` -> `YES`), and having at the same time having **format `duration(s)`**, so on that case value mappings are not very important, so I have just removed them.

Now correct expiration date is always shown in case there is a certificate (on that case `1month, 2 weeks, 2 days`):
![image](https://user-images.githubusercontent.com/41513123/100112257-522f2100-2e6f-11eb-95c6-593396014d1a.png)

The only drawback with that change, is that on cases where there is no certificate (plain HTTP, TCP...), instead of showing `N/A` it shows `No Data`:
![image](https://user-images.githubusercontent.com/41513123/100112153-2dd34480-2e6f-11eb-8d3a-8fcd67fd79b3.png)

