### PR TITLE
Add support for nodeSelector on deployments

### DIFF
--- a/deploy/crds/monitoring.3scale.net_prometheusexporters_crd.yaml
+++ b/deploy/crds/monitoring.3scale.net_prometheusexporters_crd.yaml
@@ -156,6 +156,11 @@ spec:
             configurationConfigmapName:
               type: string
               description: For cloudwatch exporter, the ConfigMap name containing Cloudwatch config.yml (Services, Dimensions, Tags used for autodiscovery...)
+            nodeSelector:
+              additionalProperties:
+                type: string
+              description: Map of nodeSelector key-value pairs
+              type: object
   version: v1alpha1
   versions:
   - name: v1alpha1

--- a/docs/prometheus-exporter-crd-reference.md
+++ b/docs/prometheus-exporter-crd-reference.md
@@ -38,6 +38,8 @@ spec:
     periodSeconds: 20
     successThreshold: 1
     failureThreshold: 7
+  nodeSlector:
+    node: test
   resources:
     requests:
       cpu: 75m
@@ -74,6 +76,7 @@ spec:
 | `readinessProbe.periodSeconds` | `int` | No | `30` | Override readiness period (seconds) |
 | `readinessProbe.successThreshold` | `int` | No | `1` | Override readiness success threshold |
 | `readinessProbe.failureThreshold` | `int` | No | `5` | Override readiness failure threshold |
+| `nodeSelector` | `map` | No | - | NodeSelector value for deployment |
 
 ## CR Spec Custom
 

--- a/docs/prometheus-exporter-crd-reference.md
+++ b/docs/prometheus-exporter-crd-reference.md
@@ -38,7 +38,7 @@ spec:
     periodSeconds: 20
     successThreshold: 1
     failureThreshold: 7
-  nodeSlector:
+  nodeSelector:
     node: test
   resources:
     requests:
@@ -76,7 +76,7 @@ spec:
 | `readinessProbe.periodSeconds` | `int` | No | `30` | Override readiness period (seconds) |
 | `readinessProbe.successThreshold` | `int` | No | `1` | Override readiness success threshold |
 | `readinessProbe.failureThreshold` | `int` | No | `5` | Override readiness failure threshold |
-| `nodeSelector` | `map` | No | - | NodeSelector value for deployment |
+| `nodeSelector` | `map` | No | - | Map of nodeSelector key-value pairs |
 
 ## CR Spec Custom
 

--- a/roles/prometheusexporter/templates/deployment.yml.j2
+++ b/roles/prometheusexporter/templates/deployment.yml.j2
@@ -131,5 +131,8 @@ spec:
             path: config.yml
 {% endif %}
 {% if node_selector is defined %}
-      nodeSelector: {{ node_selector }}
+      nodeSelector:
+{% for key, value in node_selector.items() %}
+        {{ key | safe }}: {{ value | safe }}
+{% endfor %}
 {% endif %}

--- a/roles/prometheusexporter/templates/deployment.yml.j2
+++ b/roles/prometheusexporter/templates/deployment.yml.j2
@@ -130,6 +130,6 @@ spec:
           - key: config.yml
             path: config.yml
 {% endif %}
-{% if nodeSelector is defined %}
-      nodeSelector: {{ nodeSelector }}
+{% if node_selector is defined %}
+      nodeSelector: {{ node_selector }}
 {% endif %}

--- a/roles/prometheusexporter/templates/deployment.yml.j2
+++ b/roles/prometheusexporter/templates/deployment.yml.j2
@@ -130,3 +130,6 @@ spec:
           - key: config.yml
             path: config.yml
 {% endif %}
+{% if nodeSelector is defined %}
+      nodeSelector: {{ nodeSelector }}
+{% endif %}


### PR DESCRIPTION
This adds support for nodeSelector on deployments.

I am pretty new to operators and ansible templates, so I think this will work. Certainly, will need someone more experienced to validate first.

I am trying to get the docker to build locally and testin my cluster.