### PR TITLE
Release/v0.2.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else ifeq (${UNAME}, Darwin)
   INPLACE_SED=sed -i ""
 endif
 
-VERSION ?= v0.2.0
+VERSION ?= v0.2.4
 MANIFESTS_VERSION ?= $(subst v,,$(VERSION))
 REGISTRY ?= quay.io
 ORG ?= 3scale

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A Kubernetes Operator based on the Operator SDK to centralize the setup of 3rd party prometheus exporters on **Kubernetes/OpenShift**, with a collection of grafana dashboards.
 
-You can setup different prometheus exporters to monitor the internals from different databases, or even any available cloudwatch metric from any AWS Service, by just providing a few parameters like *dbHost* or *dbPort* (operator manage the container image, port, argument, command, volumes... and also prometheus `ServiceMonitor` and `GrafanaDashboard` k8s objects).
+You can setup different prometheus exporters to monitor the **internals from different databases**, **HTTP/TCP endpoints** (availability, latency, SSL/TLS certificate expiration...), or even any available **cloudwatch metric from any AWS Service**, by just providing a few parameters like *dbHost* or *dbPort* (operator manage the container image, port, argument, command, volumes... and also prometheus `ServiceMonitor` and `GrafanaDashboard` k8s objects).
 
 Current prometheus exporters `types` supported, managed by same prometheus-exporter-operator:
 * memcached

--- a/deploy/olm-catalog/prometheus-exporter-operator/0.2.4/monitoring.3scale.net_prometheusexporters_crd.yaml
+++ b/deploy/olm-catalog/prometheus-exporter-operator/0.2.4/monitoring.3scale.net_prometheusexporters_crd.yaml
@@ -1,0 +1,168 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prometheusexporters.monitoring.3scale.net
+spec:
+  group: monitoring.3scale.net
+  names:
+    kind: PrometheusExporter
+    listKind: PrometheusExporterList
+    plural: prometheusexporters
+    singular: prometheusexporter
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: PrometheusExporter is the Schema for the prometheus exporters
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+          description: PrometheusExporterSpec defines the desired state of PrometheusExporter
+          required: ["type"]
+          properties:
+            type:
+              type: string
+              description: 'Supported prometheus-exporter types: memcached, redis, mysql, postgresql, sphinx, es, cloudwatch, probe'
+              enum:
+              - memcached
+              - redis
+              - mysql
+              - postgresql
+              - sphinx
+              - es
+              - cloudwatch
+              - probe
+            serviceMonitor:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: Create (true) or not (false) ServiceMonitor object
+                interval:
+                  type: string
+                  description: Prometheus scrape interval (example 30s)
+            grafanaDashboard:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: Create (true) or not (false) GrafanaDashboard object
+                label:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                      description: Label key used by grafana-operator for dashboard discovery
+                    value:
+                      type: string
+                      description: Label value used by grafana-operator for dashboard discovery
+            extraLabel:
+              type: object
+              properties:
+                key:
+                  type: string
+                  description: Add extra label key to all created resources (example tier)
+                  value:
+                    type: string
+                    description: Add extra label value to all created resources (example frontend)
+            image:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Prometheus exporter image name (example prom/memcached-exporter)
+                version:
+                  type: string
+                  description: Prometheus exporter image version (example v0.6.0)
+            port:
+              type: integer
+              description: Prometheus exporter port where metrics are available (example 9150)
+            resources:
+              type: object
+              properties:
+                requests:
+                  type: object
+                  properties:
+                    cpu:
+                      description: Override CPU requests (example 50m)
+                    memory:
+                      description: Override Memory requests (example 64Mi)
+                limits:
+                  type: object
+                  properties:
+                    cpu:
+                      description: Override CPU limits (example 100m)
+                    memory:
+                      description: Override Memory limits (example 256Mi)
+            livenessProbe:
+              type: object
+              properties:
+                timeoutSeconds:
+                  type: integer
+                  description: Override liveness probe timeout (seconds)
+                periodSeconds:
+                  type: integer
+                  description: Override liveness probe period (seconds)
+                successThreshold:
+                  type: integer
+                  description: Override liveness probe success threshold
+                failureThreshold:
+                  type: integer
+                  description: Override liveness probe failure threshold
+            readinessProbe:
+              type: object
+              properties:
+                timeoutSeconds:
+                  type: integer
+                  description: Override readiness probe timeout (seconds)
+                periodSeconds:
+                  type: integer
+                  description: Override readiness probe period (seconds)
+                successThreshold:
+                  type: integer
+                  description: Override readiness probe success threshold
+                failureThreshold:
+                  type: integer
+                  description: Override readiness probe failure threshold
+            dbHost:
+              type: string
+              description: For redis, memcached, sphinx and es exporters, the db host to monitor
+            dbPort:
+              type: integer
+              description: For redis, memcached, sphinx and es exporters, the db port to monitor
+            dbCheckKeys:
+              type: string
+              description: 'For redis exporter, the optional redis keys to monitor (example: resque:queue:stats,resque:queue:priority,resque:queue:main,resque:failed)'
+            dbConnectionStringSecretName:
+              type: string
+              description: For mysql and postgresql exporters, the Secret name containing connection string definition (DSN)
+            awsCredentialsSecretName:
+              type: string
+              description: For cloudwatch exporter, the Secret name containing AWS IAM credentials (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)
+            configurationConfigmapName:
+              type: string
+              description: For cloudwatch exporter, the ConfigMap name containing Cloudwatch config.yml (Services, Dimensions, Tags used for autodiscovery...)
+            nodeSelector:
+              additionalProperties:
+                type: string
+              description: Map of nodeSelector key-value pairs
+              type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/prometheus-exporter-operator/0.2.4/prometheus-exporter-operator.v0.2.4.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/prometheus-exporter-operator/0.2.4/prometheus-exporter-operator.v0.2.4.clusterserviceversion.yaml
@@ -1,0 +1,265 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "monitoring.3scale.net/v1alpha1",
+          "kind": "PrometheusExporter",
+          "metadata": {
+            "name": "example-memcached"
+          },
+          "spec": {
+            "dbHost": "your-memcached-host",
+            "dbPort": 11211,
+            "grafanaDashboard": {
+              "label": {
+                "key": "autodiscovery",
+                "value": "enabled"
+              }
+            },
+            "type": "memcached"
+          }
+        }
+      ]
+    capabilities: Deep Insights
+    categories: Monitoring
+    certified: "false"
+    containerImage: quay.io/3scale/prometheus-exporter-operator:v0.2.4
+    createdAt: "2020-06-08 00:00:00"
+    description: Operator to setup 3rd party prometheus exporters, with a collection
+      of grafana dashboards
+    repository: https://github.com/3scale/prometheus-exporter-operator
+    support: Red Hat, Inc.
+  name: prometheus-exporter-operator.v0.2.4
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Configures a prometheus exporter to monitor a memcached instance
+      displayName: PrometheusExporter
+      kind: PrometheusExporter
+      name: prometheusexporters.monitoring.3scale.net
+      version: v1alpha1
+  description: |
+    A Kubernetes Operator based on the Operator SDK to centralize the setup of 3rd party prometheus exporters on **Kubernetes/OpenShift**, with a collection of grafana dashboards.
+
+    You can setup different prometheus exporters to monitor the **internals from different databases**, **HTTP/TCP endpoints** (availability, latency, SSL/TLS certificate expiration...), or even any available **cloudwatch metric from any AWS Service**, by just providing a few parameters like **dbHost** or **dbPort** (operator manages the container image, port, argument, command, volumes... and also prometheus **ServiceMonitor** and **GrafanaDashboard** k8s objects).
+
+    Current prometheus exporters types supported, managed by same prometheus-exporter-operator:
+    * memcached
+    * redis
+    * mysql
+    * postgresql
+    * sphinx
+    * es (elasticsearch)
+    * cloudwatch
+    * probe (blackbox)
+
+    The operator manages the lifecycle of the following objects:
+    * Deployment (one per CR)
+    * Service (one per CR)
+    * ServiceMonitor (optional, one per CR)
+    * GrafanaDashboard (optional, one per Namespace)
+
+    ### Documentation
+    Documentation can be found on our [website](https://github.com/3scale/prometheus-exporter-operator#documentation).
+
+    ### Getting help
+    If you encounter any issues while using operator, you can create an issue on our [website](https://github.com/3scale/prometheus-exporter-operator) for bugs, enhancements, or other requests.
+
+    ### Contributing
+    You can contribute by:
+    * Raising any issues you find using Prometheus Exporter Operator
+    * Fixing issues by opening [Pull Requests](https://github.com/3scale/prometheus-exporter-operator/pulls)
+    * Submitting a patch or opening a PR
+    * Improving [documentation](https://github.com/3scale/prometheus-exporter-operator)
+    * Talking about Prometheus Exporter Operator
+    All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.com/3scale/prometheus-exporter-operator/issues).
+
+    ### License
+    Prometheus Exporter Operator is licensed under the [Apache 2.0 license](https://github.com/3scale/prometheus-exporter-operator/blob/master/LICENSE)
+  displayName: Prometheus Exporter Operator
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICB4bWxuczpjYz0iaHR0cDovL2NyZWF0aXZlY29tbW9ucy5vcmcvbnMjIgogICB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgaW5rc2NhcGU6dmVyc2lvbj0iMC45Mi40ICh1bmtub3duKSIKICAgaW5rc2NhcGU6ZXhwb3J0LXlkcGk9IjQxMC4xOSIKICAgaW5rc2NhcGU6ZXhwb3J0LXhkcGk9IjQxMC4xOSIKICAgaW5rc2NhcGU6ZXhwb3J0LWZpbGVuYW1lPSIvVXNlcnMvcmFlbC9Eb3dubG9hZHMvcHJvbWV0aGV1cy1leHBvcnRlci5wbmciCiAgIHNvZGlwb2RpOmRvY25hbWU9InByb21ldGhldXMtZXhwb3J0ZXItM3NjYWxlLW5ldy5zdmciCiAgIGlkPSJzdmc4NDMiCiAgIHByZXNlcnZlQXNwZWN0UmF0aW89InhNaWRZTWlkIG1lZXQiCiAgIHZpZXdCb3g9IjAgMCA3MzYuNDI1NzggNjE5Ljc0ODQ3IgogICBoZWlnaHQ9IjYxOS43NDg0N3B0IgogICB3aWR0aD0iNzM2LjQyNTc4cHQiCiAgIHZlcnNpb249IjEuMCI+CiAgPG1ldGFkYXRhCiAgICAgaWQ9Im1ldGFkYXRhODQ5Ij4KICAgIDxyZGY6UkRGPgogICAgICA8Y2M6V29yawogICAgICAgICByZGY6YWJvdXQ9IiI+CiAgICAgICAgPGRjOmZvcm1hdD5pbWFnZS9zdmcreG1sPC9kYzpmb3JtYXQ+CiAgICAgICAgPGRjOnR5cGUKICAgICAgICAgICByZGY6cmVzb3VyY2U9Imh0dHA6Ly9wdXJsLm9yZy9kYy9kY21pdHlwZS9TdGlsbEltYWdlIiAvPgogICAgICA8L2NjOldvcms+CiAgICA8L3JkZjpSREY+CiAgPC9tZXRhZGF0YT4KICA8ZGVmcwogICAgIGlkPSJkZWZzODQ3IiAvPgogIDxzb2RpcG9kaTpuYW1lZHZpZXcKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJzdmc4NDMiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIKICAgICBpbmtzY2FwZTp3aW5kb3cteT0iMjciCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjAiCiAgICAgaW5rc2NhcGU6Y3k9IjM1Ny4wNDcxNyIKICAgICBpbmtzY2FwZTpjeD0iMzc0LjM3OTciCiAgICAgaW5rc2NhcGU6em9vbT0iMC42ODc3ODIyNCIKICAgICBpbmtzY2FwZTpsb2NrZ3VpZGVzPSJ0cnVlIgogICAgIHNob3dncmlkPSJmYWxzZSIKICAgICBpZD0ibmFtZWR2aWV3ODQ1IgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEzNzYiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIyNTYwIgogICAgIGlua3NjYXBlOnBhZ2VzaGFkb3c9IjIiCiAgICAgaW5rc2NhcGU6cGFnZW9wYWNpdHk9IjAiCiAgICAgZ3VpZGV0b2xlcmFuY2U9IjEwIgogICAgIGdyaWR0b2xlcmFuY2U9IjEwIgogICAgIG9iamVjdHRvbGVyYW5jZT0iMTAiCiAgICAgYm9yZGVyb3BhY2l0eT0iMSIKICAgICBpbmtzY2FwZTpkb2N1bWVudC1yb3RhdGlvbj0iMCIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBwYWdlY29sb3I9IiNmZmZmZmYiIC8+CiAgPHBhdGgKICAgICBkPSJtIDcxNS4xMDM4NiwzMS43NDg0NzYgYyAtMTEuNSw0LjkgLTI3LjMsMTEuNSAtMzUsMTQuNyAtMjAuNiw4LjcgLTUwLDIxLjEgLTY2LjUsMjguMSAtMTcuNSw3LjUgLTM4LjEsMTYuMiAtNzEuMywzMC4wMDAwMDQgLTEzLjYsNS43IC0yNC42LDEwLjcgLTI0LjUsMTEuMSAwLjIsMC4zIDEwLjcsOS40IDIzLjMsMjAuMSAxMi43LDEwLjggMjQuOSwyMS4zIDI3LjIsMjMuNCBsIDQuMywzLjkgLTYuNyw3LjUgYyAtMzEuOSwzNi4xIC04MS41LDg2LjkgLTExMi44LDExNS43IC0xMTAuNiwxMDEuNiAtMjIyLjQsMTcwLjIgLTMyNywyMDAuOCAtMTQuNyw0LjMgLTQxLjEwMDAwMSwxMC42IC00OS41MDAwMDEsMTEuOCAtMS45LDAuMyAtNi40LDEgLTEwLDEuNSAtMy42LDAuNiAtOS40LDEuNCAtMTMsMS43IC0zLjYsMC40IC05LjQsMSAtMTMsMS41IC0zLjYsMC40IC0xNC4yLDAuNyAtMjMuNywwLjYgLTkuNTAwMDAwMywtMC4xIC0xNy4xMDAwMDAzMiwwIC0xNi45MDAwMDAzMiwwLjEgMS40MDAwMDAwMiwxLjQgMzguMzAwMDAwMzIsNi45IDU2LjAwMDAwMDMyLDguMyAxMS41LDEgNTMuNTAwMDAxLDEuMyA2NC4xMDAwMDEsMC41IDIuOCwtMC4yIDkuMywtMC42IDE0LjUsLTEgNS4yLC0wLjMgMTAuNiwtMC44IDEyLC0xIDEuNCwtMC4yIDUuMiwtMC43IDguNSwtMSAzNy40LC0zLjkgODUuNiwtMTQuOSAxMjYuNSwtMjkuMSA5MS40LC0zMS42IDE3Ny4xLC04Mi45IDI2MSwtMTU2LjUgMjAuNSwtMTcuOSA2OC4xLC02NS4yIDg2LjQsLTg1LjcgbCAxMi44LC0xNC4yIDEuOCwyLjIgYyAwLjksMS4zIDEwLjgsMTQgMjEuOSwyOC4zIDExLjEsMTQuMyAyMC41LDI2LjEgMjEsMjYuMyAwLjQsMC4xIDEuNSwtMy43IDIuNSwtOC41IDAuOSwtNC45IDYuNCwtMzMuMSAxMi4xLC02Mi44IDUuNywtMjkuNyAxMi45LC02Ny4xIDE2LC04MyAxNywtODcuODAwMDA0IDE5LjYsLTEwMS43MDAwMDQgMTkuMywtMTAyLjkwMDAwNCAtMC4yLC0wLjggLTgsMiAtMjEuMyw3LjYgeiIKICAgICBpZD0icGF0aDgzNSIKICAgICBpbmtzY2FwZTpjb25uZWN0b3ItY3VydmF0dXJlPSIwIgogICAgIHN0eWxlPSJmaWxsOiM1YTVhNWE7ZmlsbC1vcGFjaXR5OjE7c3Ryb2tlOm5vbmU7c3Ryb2tlLXdpZHRoOjAuMSIgLz4KICA8cGF0aAogICAgIGQ9Im0gMjIuMjAzODU5LDE1Ni41NDg0OCBjIDIsMTUgMTkuNiw2OS42IDI1LDc3LjUgMC44LDEuMSAxLjQsMi41IDEuNCwzLjMgMCwwLjcgMiw1LjQgNC41LDEwLjQgMi41LDUgNC41LDkuNSA0LjUsOS45IDAsMS4xIDE1LjUsMjkuNCAyMyw0MS45IDkuMywxNS43IDM2LjEwMDAwMSw1NC44IDM4LjkwMDAwMSw1NyAwLjQsMC4zIDEuOCwyLjEgMy4xLDQgMS4zLDEuOSAyLjcsMy43IDMsNCAwLjMsMC4zIDIuNCwyLjcgNC41LDUuNSAyLjIsMi43IDQuMiw1LjIgNC41LDUuNSAwLjMsMC4zIDMuNCwzLjkgNyw4IDExLjgsMTMuNyAxNy4yLDE5LjMgMzguOCw0MC43IDExLjgsMTEuNyAyMi4xLDIxLjMgMjIuNywyMS4zIDEuNywwIDYzLjksLTM0LjcgNjQuMywtMzUuOCAwLjEsLTAuNSAtNC44LC00IC0xMSwtNy43IC04MS42LC00OS4zIC0xNTYuNjAwMDAxLC0xMTcgLTE5OC41MDAwMDEsLTE3OS41IC0xNS4zLC0yMi44IC0yNywtNDUuMyAtMzUuMiwtNjcuNSAtMSwtMi43IC0xLC0yLjYgLTAuNSwxLjUgeiIKICAgICBpZD0icGF0aDgzNyIKICAgICBpbmtzY2FwZTpjb25uZWN0b3ItY3VydmF0dXJlPSIwIgogICAgIHN0eWxlPSJmaWxsOiNlYzdhMDg7ZmlsbC1vcGFjaXR5OjE7c3Ryb2tlOm5vbmU7c3Ryb2tlLXdpZHRoOjAuMSIgLz4KICA8cGF0aAogICAgIGQ9Im0gMzE4LjMwMzg2LDQ3OS40NDg0OCBjIC0yNi44LDkuNyAtNDguNywxNy45IC00OC43LDE4LjMgMCwxLjIgMzEuNSwyMS42IDUyLjgsMzQuMiA1NCwzMiAxMjkuOSw2NiAxOTAuMiw4NS4xIGwgOC41LDIuNyAyNywtMC42IGMgMjUuOSwtMC42IDI3LjgsLTAuOCA0OCwtNC42IDQwLjUsLTcuNiA2OC43LC0xNy45IDg5LjIsLTMyLjYgNi4xLC00LjMgMTAuOSwtOC4xIDEwLjcsLTguNCAtMS40LC0xLjQgLTUyLjgsLTE2IC04OS40LC0yNS40IC0xNCwtMy43IC0yNi40LC03IC0yNy41LC03LjUgLTEuMSwtMC41IC02LjEsLTEuOCAtMTEuMSwtMyAtMTAsLTIuMyAtNjQuNCwtMjAuMyAtOTAuNywtMzAgLTMwLjgsLTExLjQgLTcyLjIsLTI4LjUgLTEwNC43LC00My40IGwgLTUuNiwtMi41IHoiCiAgICAgaWQ9InBhdGg4MzkiCiAgICAgaW5rc2NhcGU6Y29ubmVjdG9yLWN1cnZhdHVyZT0iMCIKICAgICBzdHlsZT0iZmlsbDojZWM3YTA4O2ZpbGwtb3BhY2l0eToxO3N0cm9rZTpub25lO3N0cm9rZS13aWR0aDowLjEiIC8+Cjwvc3ZnPgo=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      deployments:
+      - name: prometheus-exporter-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: prometheus-exporter-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: prometheus-exporter-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: prometheus-exporter-operator
+                - name: ANSIBLE_GATHERING
+                  value: explicit
+                image: quay.io/3scale/prometheus-exporter-operator:v0.2.4
+                imagePullPolicy: Always
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /healthz
+                    port: 6789
+                  initialDelaySeconds: 30
+                  periodSeconds: 20
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                name: prometheus-exporter-operator
+                resources: {}
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+              serviceAccountName: prometheus-exporter-operator
+              volumes:
+              - emptyDir: {}
+                name: runner
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - prometheus-exporter-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - monitoring.3scale.net
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: prometheus-exporter-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - monitoring
+  - metrics
+  - observability
+  - prometheus
+  - exporter
+  - grafana
+  - mysql
+  - postgresql
+  - memcached
+  - redis
+  - sphinx
+  - elasticsearch
+  - cloudwatch
+  links:
+  - name: GitHub
+    url: https://github.com/3scale/prometheus-exporter-operator
+  maintainers:
+  - email: 3scale-operations@redhat.com
+    name: 3scale Ops
+  maturity: alpha
+  provider:
+    name: Red Hat
+  replaces: prometheus-exporter-operator.v0.2.0
+  version: 0.2.4

--- a/deploy/olm-catalog/prometheus-exporter-operator/prometheus-exporter-operator.package.yaml
+++ b/deploy/olm-catalog/prometheus-exporter-operator/prometheus-exporter-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: prometheus-exporter-operator.v0.2.0
+- currentCSV: prometheus-exporter-operator.v0.2.4
   name: alpha
 defaultChannel: alpha
 packageName: prometheus-exporter-operator


### PR DESCRIPTION
After some minor versions, `v0.2.4` will be released to OperatorHub replacing initial `v0.2.0`, so new OLM manifests have been generated.